### PR TITLE
Fix output option behavior on multiple responses

### DIFF
--- a/lib/hariko/resource/external.js
+++ b/lib/hariko/resource/external.js
@@ -6,6 +6,16 @@ var fs      = require('fs'),
 var logger = require('../../logger');
 
 function save (dest, entries) {
+  // save only first response of multiple responses
+  var save_flags = {};
+  entries = entries.filter(function (entry) {
+    if (save_flags[entry.file]) {
+      return false;
+    }
+    save_flags[entry.file] = true;
+    return true;
+  });
+
   for (var i = 0; i < entries.length; i++) {
     var entry     = entries[i],
         filepath  = path.join(dest, entry.file),

--- a/lib/hariko/resource/external.js
+++ b/lib/hariko/resource/external.js
@@ -7,12 +7,12 @@ var logger = require('../../logger');
 
 function save (dest, entries) {
   // save only first response of multiple responses
-  var save_flags = {};
+  var saveFlags = {};
   entries = entries.filter(function (entry) {
-    if (save_flags[entry.file]) {
+    if (saveFlags[entry.file]) {
       return false;
     }
-    save_flags[entry.file] = true;
+    saveFlags[entry.file] = true;
     return true;
   });
 

--- a/test/hariko/resource/external.js
+++ b/test/hariko/resource/external.js
@@ -49,11 +49,15 @@ describe('resource/external', function () {
       external.save('test/.output', [
         {file: 'api/app-GET.json', response: {data: {"message": "hello api."}}},
         {file: 'api/user/index-GET.json', response: {data: {"message": "hello world."}}},
+        {file: 'api/multiple-GET.json', response: {data: {"message": "first response."}}},
+        {file: 'api/multiple-GET.json', response: {data: {"message": "second response."}}},
       ]);
       expect(fs.readFileSync('test/.output/api/app-GET.json').toString())
         .to.be.eql('{\n    message: "hello api."\n}');
       expect(fs.readFileSync('test/.output/api/user/index-GET.json').toString())
         .to.be.eql('{\n    message: "hello world."\n}');
+      expect(fs.readFileSync('test/.output/api/multiple-GET.json').toString())
+        .to.be.eql('{\n    message: "first response."\n}');
     });
   });
 

--- a/test/hariko/resource/external.js
+++ b/test/hariko/resource/external.js
@@ -49,15 +49,15 @@ describe('resource/external', function () {
       external.save('test/.output', [
         {file: 'api/app-GET.json', response: {data: {"message": "hello api."}}},
         {file: 'api/user/index-GET.json', response: {data: {"message": "hello world."}}},
-        {file: 'api/multiple-GET.json', response: {data: {"message": "first response."}}},
-        {file: 'api/multiple-GET.json', response: {data: {"message": "second response."}}},
+        {file: 'api/multiple-GET.json', response: {data: {"message": "first."}}},
+        {file: 'api/multiple-GET.json', response: {data: {"message": "second."}}},
       ]);
       expect(fs.readFileSync('test/.output/api/app-GET.json').toString())
         .to.be.eql('{\n    message: "hello api."\n}');
       expect(fs.readFileSync('test/.output/api/user/index-GET.json').toString())
         .to.be.eql('{\n    message: "hello world."\n}');
       expect(fs.readFileSync('test/.output/api/multiple-GET.json').toString())
-        .to.be.eql('{\n    message: "first response."\n}');
+        .to.be.eql('{\n    message: "first."\n}');
     });
   });
 


### PR DESCRIPTION
When output option is enabled and resource/method has multiple responses,
response body and the others (ex. status code) are mismatching after start/restart.
Current output option behavior is saving(overwriting) all response bodies and last response body is enabled in same resource+method.
But the others(ex. status code) is not so.
This change will save only first response in same resource+method.
